### PR TITLE
assembly definition の設定を行うことでランタイムビルドのコンパイルエラーを直す

### DIFF
--- a/Assets/GlitchShader/Editor/GlitchShaderGUI.asmdef
+++ b/Assets/GlitchShader/Editor/GlitchShaderGUI.asmdef
@@ -1,3 +1,15 @@
-﻿{
-	"name": "GlitchShaderGUI"
+{
+    "name": "GlitchShaderGUI",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
https://misskey.niri.la/notes/9gtjj519hn

ランタイムビルドがコンパイルエラーを吐いたいたのでasmdefの修正を行いました

同時に勝手にAssembly-CSharpから参照されるのを参照されないようにしました
また、プロジェクトにあるdllをすべて参照してコンパイルする設定になってたため、そうでなくしました。